### PR TITLE
Fix/repo dependent actions

### DIFF
--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   # Build job
   build:
+    if: github.repository == 'nrel/altrios'
     runs-on: ubuntu-latest
     env:
       MDBOOK_VERSION: 0.4.21
@@ -49,6 +50,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: github.repository == 'nrel/altrios'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -7,11 +7,6 @@ on:
     paths:
       - "docs/**"
       - ".github/workflows/deploy-book.yaml"
-  pull_request:
-    branches: ["main"]
-    paths:
-      - "docs/**"
-      - ".github/workflows/deploy-book.yaml"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   # Build job
   build:
-    if: github.repository == 'nrel/altrios'
+    if: github.repository == 'nrel/altrios' || github.repository == 'nrel/altrios-private'
     runs-on: ubuntu-latest
     env:
       MDBOOK_VERSION: 0.4.21
@@ -50,7 +50,7 @@ jobs:
 
   # Deployment job
   deploy:
-    if: github.repository == 'nrel/altrios'
+    if: github.repository == 'nrel/altrios' || github.repository == 'nrel/altrios-private'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,39 +10,41 @@ on:
 
 jobs:
   test:
-      runs-on: ubuntu-latest
+    if: github.repository == 'nrel/altrios'
 
-      strategy:
-        fail-fast: false
-        matrix:
-          python-version: ['3.9', '3.10']
+    runs-on: ubuntu-latest
 
-      env:
-        PYTHON: ${{ matrix.python-version }}
-        SHOW_PLOTS: false
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10']
 
-      steps:
-      - uses: actions/checkout@v3
+    env:
+      PYTHON: ${{ matrix.python-version }}
+      SHOW_PLOTS: false
 
-      - name: set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
+    steps:
+    - uses: actions/checkout@v3
 
-      - name: install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable 
-          override: true
+    - name: set up python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
 
-      - name: Rust unit tests
-        run: |
-          cd rust/
-          cargo test
+    - name: install rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable 
+        override: true
 
-      - name: Python unit tests 
-        run: |
-          pip install maturin pytest
-          pip install -e ".[dev]" 
-          pytest python/altrios -s
+    - name: Rust unit tests
+      run: |
+        cd rust/
+        cargo test
+
+    - name: Python unit tests 
+      run: |
+        pip install maturin pytest
+        pip install -e ".[dev]" 
+        pytest python/altrios -s

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    if: github.repository == 'nrel/altrios'
+    if: github.repository == 'nrel/altrios' || github.repository == 'nrel/altrios-private'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,8 +5,8 @@ on:
       branches: [ main ]
   pull_request:
   workflow_dispatch:
-  release:
-    types: [published]
+  workflow_call:
+
 
 jobs:
   test:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'nrel/altrios'
     name: build py3.${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
     strategy:
       fail-fast: false
@@ -83,6 +84,7 @@ jobs:
           path: dist 
 
   upload:
+    if: github.repository == 'nrel/altrios'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -3,14 +3,11 @@ name: wheels
 on:
   release:
     types: [published]
-  workflow_run: 
-    workflows: ["tests"]
-    types:
-      - completed
 
 jobs:
+  call-tests:
+    uses: nrel/altrios/.github/workflows/tests.yaml
   build:
-    if: github.repository == 'nrel/altrios' || github.repository == 'nrel/altrios-private'
     name: build py3.${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
     strategy:
       fail-fast: false
@@ -27,7 +24,6 @@ jobs:
             platform: linux
           - os: windows
             ls: dir
-    if: github.event_name == 'release' && github.event.action == 'published' && github.event.workflow_run.conclusion == 'success'
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    if: github.repository == 'nrel/altrios'
+    if: github.repository == 'nrel/altrios' || github.repository == 'nrel/altrios-private'
     name: build py3.${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
     strategy:
       fail-fast: false
@@ -84,7 +84,7 @@ jobs:
           path: dist 
 
   upload:
-    if: github.repository == 'nrel/altrios'
+    if: github.repository == 'nrel/altrios' || github.repository == 'nrel/altrios-private'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
- turns off github actions in nrel VPN since there are no runners
- makes wheels depend on tests as a reusable, callable workflow