### PR TITLE
Metrics renaming

### DIFF
--- a/python/altrios/tests/test_metric_calculator.py
+++ b/python/altrios/tests/test_metric_calculator.py
@@ -23,5 +23,5 @@ class TestMetricCalculator(unittest.TestCase):
             
         for info in scenario_infos:
             tkm = metric_calculator.calculate_freight(info,'Million_Tonne-KM')
-            self.assertEqual(tkm.filter(pl.col("Metric") == 'Mt-km').get_column("Units").len(), 0)
+            self.assertEqual(tkm.filter(pl.col("Metric") == 'Mt-km').get_column("Units").len(), 1)
 

--- a/python/altrios/tests/test_metric_calculator.py
+++ b/python/altrios/tests/test_metric_calculator.py
@@ -22,6 +22,6 @@ class TestMetricCalculator(unittest.TestCase):
                 False))
             
         for info in scenario_infos:
-            tkm = metric_calculator.calculate_tkm(info,'million_tonne_km')
-            self.assertEqual(tkm.filter(pl.col("Metric") == 'TKM').get_column("Units").len(), 0)
+            tkm = metric_calculator.calculate_freight(info,'Million_Tonne-KM')
+            self.assertEqual(tkm.filter(pl.col("Metric") == 'Mt-km').get_column("Units").len(), 0)
 


### PR DESCRIPTION
Fixes for clarity of the different cost and freight delivery metrics:

- Renamed metric "TKM" to "Mt-km"
- Revised units for discounting factor and for Mt-km
- Added "_Discounted" and "_Levelized" suffixes to metric names and units where appropriate. Metric values are un-discounted otherwise.
- Code cleanup for the assignment of the affected metrics.