### PR TITLE
Fix/use pwr aux

### DIFF
--- a/rust/altrios-core/src/consist/consist_model.rs
+++ b/rust/altrios-core/src/consist/consist_model.rs
@@ -123,7 +123,6 @@ pub struct Consist {
 impl SerdeAPI for Consist {
     fn init(&mut self) -> anyhow::Result<()> {
         self.check_mass_consistent()?;
-        self.update_mass(None)?;
         Ok(())
     }
 }

--- a/rust/altrios-core/src/consist/consist_model.rs
+++ b/rust/altrios-core/src/consist/consist_model.rs
@@ -241,6 +241,13 @@ impl Consist {
             .sum::<si::Energy>()
     }
 
+    pub fn set_pwr_aux(&mut self, engine_on: Option<bool>) -> anyhow::Result<()> {
+        self.loco_vec
+            .iter_mut()
+            .for_each(|l| l.set_pwr_aux(engine_on));
+        Ok(())
+    }
+
     pub fn solve_energy_consumption(
         &mut self,
         pwr_out_req: si::Power,

--- a/rust/altrios-core/src/consist/consist_sim.rs
+++ b/rust/altrios-core/src/consist/consist_sim.rs
@@ -83,6 +83,7 @@ impl ConsistSimulation {
     }
 
     pub fn solve_step(&mut self) -> anyhow::Result<()> {
+        self.loco_con.set_pwr_aux(Some(true))?;
         self.loco_con
             .set_cur_pwr_max_out(None, self.power_trace.dt(self.i))?;
         self.solve_energy_consumption(self.power_trace.pwr[self.i], self.power_trace.dt(self.i))?;

--- a/rust/altrios-core/src/consist/locomotive/battery_electric_loco.rs
+++ b/rust/altrios-core/src/consist/locomotive/battery_electric_loco.rs
@@ -71,7 +71,11 @@ impl LocoTrait for BatteryElectricLoco {
         dt: si::Time,
     ) -> anyhow::Result<()> {
         // TODO: proposed interface location to feed in the catenary
-        self.res.set_cur_pwr_out_max(pwr_aux.unwrap(), None, None)?;
+        self.res.set_cur_pwr_out_max(
+            pwr_aux.ok_or(anyhow!(format_dbg!("`pwr_aux` not provided")))?,
+            None,
+            None,
+        )?;
         self.edrv
             .set_cur_pwr_max_out(self.res.state.pwr_prop_out_max, None)?;
         self.edrv

--- a/rust/altrios-core/src/consist/locomotive/conventional_loco.rs
+++ b/rust/altrios-core/src/consist/locomotive/conventional_loco.rs
@@ -93,8 +93,10 @@ impl LocoTrait for ConventionalLoco {
         dt: si::Time,
     ) -> anyhow::Result<()> {
         self.fc.set_cur_pwr_out_max(dt)?;
-        self.gen
-            .set_cur_pwr_max_out(self.fc.state.pwr_out_max, pwr_aux)?;
+        self.gen.set_cur_pwr_max_out(
+            self.fc.state.pwr_out_max,
+            Some(pwr_aux.ok_or(anyhow!(format_dbg!("`pwr_aux` not provided")))?),
+        )?;
         self.edrv
             .set_cur_pwr_max_out(self.gen.state.pwr_elec_prop_out_max, None)?;
         self.gen

--- a/rust/altrios-core/src/consist/locomotive/hybrid_loco.rs
+++ b/rust/altrios-core/src/consist/locomotive/hybrid_loco.rs
@@ -87,7 +87,11 @@ impl LocoTrait for Box<HybridLoco> {
         pwr_aux: Option<si::Power>,
         dt: si::Time,
     ) -> anyhow::Result<()> {
-        self.res.set_cur_pwr_out_max(pwr_aux.unwrap(), None, None)?;
+        self.res.set_cur_pwr_out_max(
+            pwr_aux.ok_or(anyhow!(format_dbg!("`pwr_aux` not provided")))?,
+            None,
+            None,
+        )?;
         self.fc.set_cur_pwr_out_max(dt)?;
 
         self.gen

--- a/rust/altrios-core/src/consist/locomotive/locomotive_model.rs
+++ b/rust/altrios-core/src/consist/locomotive/locomotive_model.rs
@@ -499,7 +499,6 @@ impl Default for Locomotive {
 impl SerdeAPI for Locomotive {
     fn init(&mut self) -> anyhow::Result<()> {
         self.check_mass_consistent()?;
-        self.update_mass(None)?;
         Ok(())
     }
 }

--- a/rust/altrios-core/src/meet_pass.rs
+++ b/rust/altrios-core/src/meet_pass.rs
@@ -1,4 +1,3 @@
-#![warn(missing_docs)]
 //! Meet-pass
 //!
 //! # Nomenclature

--- a/rust/altrios-core/src/prelude.rs
+++ b/rust/altrios-core/src/prelude.rs
@@ -17,6 +17,8 @@ pub use crate::consist::locomotive::{
     LocomotiveState, LocomotiveStateHistoryVec,
 };
 
+pub use crate::consist::locomotive::powertrain::powertrain_traits::*;
+
 pub use crate::consist::consist_sim::ConsistSimulation;
 pub use crate::consist::{Consist, ConsistState, ConsistStateHistoryVec};
 

--- a/rust/altrios-core/src/track.rs
+++ b/rust/altrios-core/src/track.rs
@@ -1,4 +1,3 @@
-#![warn(missing_docs)]
 mod link;
 mod path_track;
 

--- a/rust/altrios-core/src/train.rs
+++ b/rust/altrios-core/src/train.rs
@@ -1,4 +1,3 @@
-#![warn(missing_docs)]
 mod braking_point;
 mod friction_brakes;
 mod rail_vehicle;

--- a/rust/altrios-core/src/train/set_speed_train_sim.rs
+++ b/rust/altrios-core/src/train/set_speed_train_sim.rs
@@ -310,6 +310,7 @@ impl SetSpeedTrainSim {
         self.loco_con
             .set_cat_power_limit(&self.path_tpc, self.state.offset);
 
+        self.loco_con.set_pwr_aux(Some(true))?;
         self.loco_con
             .set_cur_pwr_max_out(None, self.speed_trace.dt(self.state.i))?;
         self.train_res

--- a/rust/altrios-core/src/train/speed_limit_train_sim.rs
+++ b/rust/altrios-core/src/train/speed_limit_train_sim.rs
@@ -275,6 +275,7 @@ impl SpeedLimitTrainSim {
     pub fn solve_step(&mut self) -> anyhow::Result<()> {
         self.loco_con
             .set_cat_power_limit(&self.path_tpc, self.state.offset);
+        self.loco_con.set_pwr_aux(Some(true))?;
         self.loco_con.set_cur_pwr_max_out(None, self.state.dt)?;
         self.train_res
             .update_res::<{ Dir::Fwd }>(&mut self.state, &self.path_tpc)?;


### PR DESCRIPTION
- all instances of `solve_step` set `pwr_aux` 
- `pwr_aux` is always set, regardless of whether the locomotive is moving or not
- TODO: maybe implement some fancier control logic that can selectively turn off locomotives