### PR TITLE
compiles with `DirT` replaced by an enum but 3 tests fail

### DIFF
--- a/rust/altrios-core/src/lin_search_hint.rs
+++ b/rust/altrios-core/src/lin_search_hint.rs
@@ -1,6 +1,7 @@
 use crate::imports::*;
 use crate::si;
 
+#[derive(PartialEq)]
 pub enum Dir {
     Unk,
     Fwd,
@@ -23,28 +24,24 @@ pub trait LinSearchHint {
 
 impl<T: GetOffset + core::fmt::Debug> LinSearchHint for &[T] {
     fn calc_idx(&self, offset: si::Length, mut idx: usize, dir: &Dir) -> anyhow::Result<usize> {
-        match dir {
-            Dir::Bwd => {
-                ensure!(
-                    offset <= self.last().unwrap().get_offset(),
-                    "{}\nOffset larger than last slice offset!",
-                    format_dbg!()
-                );
-                while self[idx + 1].get_offset() < offset {
-                    idx += 1;
-                }
+        if dir != &Dir::Bwd {
+            ensure!(
+                offset <= self.last().unwrap().get_offset(),
+                "{}\nOffset larger than last slice offset!",
+                format_dbg!()
+            );
+            while self[idx + 1].get_offset() < offset {
+                idx += 1;
             }
-            Dir::Fwd => {
-                ensure!(
-                    self.first().unwrap().get_offset() <= offset,
-                    "{}\nOffset smaller than first slice offset!",
-                    format_dbg!()
-                );
-                while offset < self[idx].get_offset() {
-                    idx -= 1;
-                }
+        } else if dir != &Dir::Fwd {
+            ensure!(
+                self.first().unwrap().get_offset() <= offset,
+                "{}\nOffset smaller than first slice offset!",
+                format_dbg!()
+            );
+            while offset < self[idx].get_offset() {
+                idx -= 1;
             }
-            _ => {}
         }
         Ok(idx)
     }

--- a/rust/altrios-core/src/lin_search_hint.rs
+++ b/rust/altrios-core/src/lin_search_hint.rs
@@ -1,18 +1,10 @@
 use crate::imports::*;
 use crate::si;
 
-// Per Geordie, we could probably get rid of this `DirT` code
-pub type DirT = u8;
-
-#[allow(non_snake_case)]
-pub mod Dir {
-    pub use super::*;
-    #[allow(non_upper_case_globals)]
-    pub const Unk: DirT = 0;
-    #[allow(non_upper_case_globals)]
-    pub const Fwd: DirT = 1;
-    #[allow(non_upper_case_globals)]
-    pub const Bwd: DirT = 2;
+pub enum Dir {
+    Unk,
+    Fwd,
+    Bwd,
 }
 
 /// Has method that returns offset from start of PathTpc
@@ -26,34 +18,33 @@ pub trait GetOffset {
 pub trait LinSearchHint {
     /// Calculate the index immediately before `offset` given the previous calculated index, `idx`,
     /// and a direction `DirT`.
-    fn calc_idx<const DIR: DirT>(&self, offset: si::Length, idx: usize) -> anyhow::Result<usize>;
+    fn calc_idx(&self, offset: si::Length, idx: usize, dir: &Dir) -> anyhow::Result<usize>;
 }
 
 impl<T: GetOffset + core::fmt::Debug> LinSearchHint for &[T] {
-    fn calc_idx<const DIR: DirT>(
-        &self,
-        offset: si::Length,
-        mut idx: usize,
-    ) -> anyhow::Result<usize> {
-        if DIR != Dir::Bwd {
-            ensure!(
-                offset <= self.last().unwrap().get_offset(),
-                "{}\nOffset larger than last slice offset!",
-                format_dbg!()
-            );
-            while self[idx + 1].get_offset() < offset {
-                idx += 1;
+    fn calc_idx(&self, offset: si::Length, mut idx: usize, dir: &Dir) -> anyhow::Result<usize> {
+        match dir {
+            Dir::Bwd => {
+                ensure!(
+                    offset <= self.last().unwrap().get_offset(),
+                    "{}\nOffset larger than last slice offset!",
+                    format_dbg!()
+                );
+                while self[idx + 1].get_offset() < offset {
+                    idx += 1;
+                }
             }
-        }
-        if DIR != Dir::Fwd {
-            ensure!(
-                self.first().unwrap().get_offset() <= offset,
-                "{}\nOffset smaller than first slice offset!",
-                format_dbg!()
-            );
-            while offset < self[idx].get_offset() {
-                idx -= 1;
+            Dir::Fwd => {
+                ensure!(
+                    self.first().unwrap().get_offset() <= offset,
+                    "{}\nOffset smaller than first slice offset!",
+                    format_dbg!()
+                );
+                while offset < self[idx].get_offset() {
+                    idx -= 1;
+                }
             }
+            _ => {}
         }
         Ok(idx)
     }

--- a/rust/altrios-core/src/train/braking_point.rs
+++ b/rust/altrios-core/src/train/braking_point.rs
@@ -103,7 +103,17 @@ impl BrakingPoints {
                     train_state.speed = bp_curr.speed_limit;
                     train_res.update_res(&mut train_state, path_tpc, &Dir::Bwd)?;
 
-                    ensure!(fric_brake.force_max + train_state.res_net() > si::Force::ZERO);
+                    ensure!(
+                        fric_brake.force_max + train_state.res_net() > si::Force::ZERO,
+                        format!(
+                            "{}\n{}\n{}",
+                            format_dbg!(
+                                fric_brake.force_max + train_state.res_net() > si::Force::ZERO
+                            ),
+                            format_dbg!(fric_brake.force_max),
+                            format_dbg!(train_state.res_net()),
+                        )
+                    );
                     let vel_change = train_state.dt
                         * (fric_brake.force_max + train_state.res_net())
                         / train_state.mass_static;

--- a/rust/altrios-core/src/train/braking_point.rs
+++ b/rust/altrios-core/src/train/braking_point.rs
@@ -81,7 +81,7 @@ impl BrakingPoints {
         let mut train_res = train_res.clone();
         train_state.offset = path_tpc.offset_end();
         train_state.speed = si::Velocity::ZERO;
-        train_res.update_res::<{ Dir::Unk }>(&mut train_state, path_tpc)?;
+        train_res.update_res(&mut train_state, path_tpc, &Dir::Unk)?;
         let speed_points = path_tpc.speed_points();
         let mut idx = path_tpc.speed_points().len();
 
@@ -101,7 +101,7 @@ impl BrakingPoints {
 
                     train_state.offset = bp_curr.offset;
                     train_state.speed = bp_curr.speed_limit;
-                    train_res.update_res::<{ Dir::Bwd }>(&mut train_state, path_tpc)?;
+                    train_res.update_res(&mut train_state, path_tpc, &Dir::Bwd)?;
 
                     assert!(fric_brake.force_max + train_state.res_net() > si::Force::ZERO);
                     let vel_change = train_state.dt

--- a/rust/altrios-core/src/train/braking_point.rs
+++ b/rust/altrios-core/src/train/braking_point.rs
@@ -103,7 +103,7 @@ impl BrakingPoints {
                     train_state.speed = bp_curr.speed_limit;
                     train_res.update_res(&mut train_state, path_tpc, &Dir::Bwd)?;
 
-                    assert!(fric_brake.force_max + train_state.res_net() > si::Force::ZERO);
+                    ensure!(fric_brake.force_max + train_state.res_net() > si::Force::ZERO);
                     let vel_change = train_state.dt
                         * (fric_brake.force_max + train_state.res_net())
                         / train_state.mass_static;

--- a/rust/altrios-core/src/train/resistance/method/point.rs
+++ b/rust/altrios-core/src/train/resistance/method/point.rs
@@ -16,10 +16,11 @@ pub struct Point {
 }
 
 impl ResMethod for Point {
-    fn update_res<const DIR: DirT>(
+    fn update_res(
         &mut self,
         state: &mut TrainState,
         path_tpc: &PathTpc,
+        dir: &Dir,
     ) -> anyhow::Result<()> {
         state.offset_back = state.offset - state.length;
         state.weight_static = state.mass_static * uc::ACC_GRAV;
@@ -27,8 +28,8 @@ impl ResMethod for Point {
         state.res_rolling = self.rolling.calc_res(state);
         state.res_davis_b = self.davis_b.calc_res(state);
         state.res_aero = self.aerodynamic.calc_res(state);
-        state.res_grade = self.grade.calc_res::<DIR>(path_tpc.grades(), state)?;
-        state.res_curve = self.curve.calc_res::<DIR>(path_tpc.curves(), state)?;
+        state.res_grade = self.grade.calc_res(path_tpc.grades(), state, dir)?;
+        state.res_curve = self.curve.calc_res(path_tpc.curves(), state, dir)?;
         state.grade_front = self.grade.res_coeff_front(path_tpc.grades());
         state.elev_front = self.grade.res_net_front(path_tpc.grades(), state);
         Ok(())

--- a/rust/altrios-core/src/train/resistance/method/strap.rs
+++ b/rust/altrios-core/src/train/resistance/method/strap.rs
@@ -35,10 +35,11 @@ impl Strap {
     }
 }
 impl ResMethod for Strap {
-    fn update_res<const DIR: DirT>(
+    fn update_res(
         &mut self,
         state: &mut TrainState,
         path_tpc: &PathTpc,
+        dir: &Dir,
     ) -> anyhow::Result<()> {
         state.offset_back = state.offset - state.length;
         state.weight_static = state.mass_static * uc::ACC_GRAV;
@@ -46,8 +47,8 @@ impl ResMethod for Strap {
         state.res_rolling = self.rolling.calc_res(state);
         state.res_davis_b = self.davis_b.calc_res(state);
         state.res_aero = self.aerodynamic.calc_res(state);
-        state.res_grade = self.grade.calc_res::<DIR>(path_tpc.grades(), state)?;
-        state.res_curve = self.curve.calc_res::<DIR>(path_tpc.curves(), state)?;
+        state.res_grade = self.grade.calc_res(path_tpc.grades(), state, dir)?;
+        state.res_curve = self.curve.calc_res(path_tpc.curves(), state, dir)?;
         state.grade_front = self.grade.res_coeff_front(path_tpc.grades());
         state.elev_front = self.grade.res_net_front(path_tpc.grades(), state);
         Ok(())

--- a/rust/altrios-core/src/train/resistance/mod.rs
+++ b/rust/altrios-core/src/train/resistance/mod.rs
@@ -8,10 +8,11 @@ use crate::train::TrainState;
 
 #[enum_dispatch]
 pub trait ResMethod {
-    fn update_res<const DIR: DirT>(
+    fn update_res(
         &mut self,
         state: &mut TrainState,
         path_tpc: &PathTpc,
+        dir: &Dir,
     ) -> anyhow::Result<()>;
     fn fix_cache(&mut self, link_point_del: &LinkPoint);
 }

--- a/rust/altrios-core/src/train/set_speed_train_sim.rs
+++ b/rust/altrios-core/src/train/set_speed_train_sim.rs
@@ -314,7 +314,7 @@ impl SetSpeedTrainSim {
         self.loco_con
             .set_cur_pwr_max_out(None, self.speed_trace.dt(self.state.i))?;
         self.train_res
-            .update_res::<{ Dir::Fwd }>(&mut self.state, &self.path_tpc)?;
+            .update_res(&mut self.state, &self.path_tpc, &Dir::Fwd)?;
         self.solve_required_pwr(self.speed_trace.dt(self.state.i));
         self.loco_con.solve_energy_consumption(
             self.state.pwr_whl_out,

--- a/rust/altrios-core/src/train/speed_limit_train_sim.rs
+++ b/rust/altrios-core/src/train/speed_limit_train_sim.rs
@@ -287,7 +287,7 @@ impl SpeedLimitTrainSim {
         self.loco_con.set_pwr_aux(Some(true))?;
         self.loco_con.set_cur_pwr_max_out(None, self.state.dt)?;
         self.train_res
-            .update_res::<{ Dir::Fwd }>(&mut self.state, &self.path_tpc)?;
+            .update_res(&mut self.state, &self.path_tpc, &Dir::Fwd)?;
         self.solve_required_pwr()?;
         self.loco_con.solve_energy_consumption(
             self.state.pwr_whl_out,


### PR DESCRIPTION
# `python sim_manager_demo.py` on `fix/change-DirT-to-enum`
```
python sim_manager_demo.py 
Elapsed time to import rail vehicles, locations, and network: 0.088 s
Entering `sim_manager` module.
2024-02-14 13:31:47
/Users/cbaker2/Documents/Projects/altrios/altrios_code/python/altrios/resources/Default Demand.csv
Elapsed time to plan train consist for year 2022: 25 s
Elapsed time to run dispatch for year 2022: 0.497 s
Elapsed time to run `sim_manager.main()`: 25.5 s
Elapsed time to run train sims: 2.05 s
Elapsed time to build and run summary sims: 2 s
Elapsed time to run `tolist()`: 0.00347 s
Elapsed time to get total fuel energy: 7.08e-06 s
Total fuel energy used: 1.96e+03 GJ
Total fuel used: 1.18e+04 gallons
```

# `python sim_manager_demo.py` on `main`
```
Elapsed time to import rail vehicles, locations, and network: 0.0907 s
Entering `sim_manager` module.
2024-02-14 13:35:04
/Users/cbaker2/Documents/Projects/altrios/altrios_code/python/altrios/resources/Default Demand.csv
Elapsed time to plan train consist for year 2022: 25 s
Elapsed time to run dispatch for year 2022: 0.497 s
Elapsed time to run `sim_manager.main()`: 25.5 s
Elapsed time to run train sims: 2.03 s
Elapsed time to build and run summary sims: 1.98 s
Elapsed time to run `tolist()`: 0.00394 s
Elapsed time to get total fuel energy: 2.43e-05 s
Total fuel energy used: 1.96e+03 GJ
Total fuel used: 1.18e+04 gallons
```

# Conclusion
This PR makes the code more readable and maintainable without any obvious computational penalty.