### PR TITLE
Removed history to improve memory management in make_est_times

### DIFF
--- a/rust/altrios-core/src/meet_pass/dispatch.rs
+++ b/rust/altrios-core/src/meet_pass/dispatch.rs
@@ -323,7 +323,7 @@ mod test_dispatch {
 
         let est_time_vec = train_sims
             .iter()
-            .map(|slts| make_est_times(slts, &network).unwrap().0)
+            .map(|slts| make_est_times(slts.clone(), &network).unwrap().0)
             .collect::<Vec<EstTimeNet>>();
         let _output = run_dispatch(&network, &train_sims, est_time_vec, true, true).unwrap();
     }

--- a/rust/altrios-core/src/meet_pass/est_times/mod.rs
+++ b/rust/altrios-core/src/meet_pass/est_times/mod.rs
@@ -474,9 +474,10 @@ fn add_new_join_paths(
 }
 
 pub fn make_est_times<N: AsRef<[Link]>>(
-    speed_limit_train_sim: &SpeedLimitTrainSim,
+    mut speed_limit_train_sim: SpeedLimitTrainSim,  
     network: N,
 ) -> anyhow::Result<(EstTimeNet, Consist)> {
+    speed_limit_train_sim.set_save_interval(None);
     let network = network.as_ref();
     let dests = &speed_limit_train_sim.dests;
     let (link_idx_options, origs) =
@@ -485,7 +486,7 @@ pub fn make_est_times<N: AsRef<[Link]>>(
 
     let mut est_times = Vec::with_capacity(network.len() * 10);
     let mut consist_out = None;
-    let mut saved_sims = Vec::<SavedSim>::with_capacity(16.max(network.len() / 10));
+    let mut saved_sims: Vec<SavedSim> = vec![];
     let mut link_event_map =
         LinkEventMap::with_capacity_and_hasher(est_times.capacity(), Default::default());
     let time_depart = speed_limit_train_sim.state.time;
@@ -778,5 +779,5 @@ pub fn make_est_times_py(
         }
     };
 
-    make_est_times(&speed_limit_train_sim, network)
+    make_est_times(speed_limit_train_sim, network)
 }

--- a/rust/altrios-core/src/meet_pass/train_disp/mod.rs
+++ b/rust/altrios-core/src/meet_pass/train_disp/mod.rs
@@ -226,7 +226,7 @@ mod test_train_disp {
         let network = Network::from_file(network_file_path).unwrap();
 
         let speed_limit_train_sim = crate::train::speed_limit_train_sim_fwd();
-        let est_times = make_est_times(&speed_limit_train_sim, network).unwrap().0;
+        let est_times = make_est_times(speed_limit_train_sim.clone(), network).unwrap().0;
         TrainDisp::new(
             speed_limit_train_sim.train_id.clone(),
             NonZeroU16::new(1),
@@ -249,7 +249,7 @@ mod test_train_disp {
         let network = Network::from_file(network_file_path).unwrap();
 
         let speed_limit_train_sim = crate::train::speed_limit_train_sim_rev();
-        let est_times = make_est_times(&speed_limit_train_sim, network).unwrap().0;
+        let est_times = make_est_times(speed_limit_train_sim.clone(), network).unwrap().0;
         TrainDisp::new(
             speed_limit_train_sim.train_id.clone(),
             NonZeroU16::new(1),


### PR DESCRIPTION
Modified the definition of `saved_sims` vector in make_est_times function to improve memory management while running meet pass planner.