### PR TITLE
bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "altrios"
-version = "0.2.3"
+version = "0.3.0"
 authors = [
     { name = "ALTRIOS Team", email = "altrios@nrel.gov" },
     { name = "Chad Baker, Lead Developer" },


### PR DESCRIPTION
Proposing to bump the version to 0.3.0 in anticipation of a new PyPI release. This is timely since for the parallel system web tool, we want to point to a stable version. 