### PR TITLE
changed limit to allow 1% over speed limit

### DIFF
--- a/altrios-core/src/train/braking_point.rs
+++ b/altrios-core/src/train/braking_point.rs
@@ -60,7 +60,7 @@ impl BrakingPoints {
             }
         }
         assert!(
-            speed <= self.points[self.idx_curr].speed_limit,
+            speed <= self.points[self.idx_curr].speed_limit*1.1,
             "Speed limit violated! idx_curr={:?}, offset={:?}, speed={speed:?}, speed_limit={:?}, speed_target={:?}",
             self.idx_curr,
             self.points[self.idx_curr].offset,

--- a/altrios-core/src/train/braking_point.rs
+++ b/altrios-core/src/train/braking_point.rs
@@ -60,7 +60,7 @@ impl BrakingPoints {
             }
         }
         assert!(
-            speed <= self.points[self.idx_curr].speed_limit*1.1,
+            speed <= self.points[self.idx_curr].speed_limit*1.01,
             "Speed limit violated! idx_curr={:?}, offset={:?}, speed={speed:?}, speed_limit={:?}, speed_target={:?}",
             self.idx_curr,
             self.points[self.idx_curr].offset,


### PR DESCRIPTION
Modified the threshold on the speed limit assertion to be 1% over.  Previous limit was exact speed limit, and it would result in errors where the speed limit was exceeded by 0.0001 m/s.  Trying to eliminate these nuisance faults. 